### PR TITLE
Add CH4 offset capability

### DIFF
--- a/GeosCore/set_global_ch4_mod.F90
+++ b/GeosCore/set_global_ch4_mod.F90
@@ -108,6 +108,7 @@ CONTAINS
 
 #if defined( MODEL_GEOS )
     REAL(hp), ALLOCATABLE :: GEOS_CH4(:,:,:)
+    REAL(hp), ALLOCATABLE :: CH4_OFFSET(:,:)
     LOGICAL               :: USE_GEOS_CH4
 #endif
     LOGICAL, SAVE         :: FIRST = .TRUE.
@@ -136,6 +137,13 @@ CONTAINS
     FOUND   = .FALSE.
     SRCNAME = ''
 #if defined( MODEL_GEOS )
+    ! Check for CH4 offset first
+    ALLOCATE(CH4_OFFSET(State_Grid%NX,State_Grid%NY))
+    CH4_OFFSET(:,:) = 0.0
+    CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'CH4_OFFSET', &
+                         CH4_OFFSET, RC, FOUND=FOUND )
+    IF ( .NOT. FOUND ) CH4_OFFSET = 0.0
+    ! Now get CH4 concentrations
     ALLOCATE(GEOS_CH4(State_Grid%NX,State_Grid%NY,State_Grid%NZ))
     GEOS_CH4(:,:,:) = 0.0
     CALL HCO_GC_EvalFld( Input_Opt, State_Grid, 'GEOS_CH4', &
@@ -215,7 +223,7 @@ CONTAINS
 
        ! In GEOS, we may be getting CH4 from a 3D field 
 #if defined( MODEL_GEOS )
-          IF ( USE_GEOS_CH4 ) CH4 = GEOS_CH4(I,J,L)
+          IF ( USE_GEOS_CH4 ) CH4 = GEOS_CH4(I,J,L) + CH4_OFFSET(I,J)
 #endif
 
           ! Compute implied CH4 flux if diagnostic is on
@@ -241,6 +249,12 @@ CONTAINS
     ! Convert species back to original unit
     CALL Convert_Spc_Units( Input_Opt, State_Chm, State_Grid, State_Met, &
                             OrigUnit, RC )
+
+    ! Cleanup
+#if defined( MODEL_GEOS )
+    IF(ALLOCATED(GEOS_CH4))   DEALLOCATE(GEOS_CH4)
+    IF(ALLOCATED(CH4_OFFSET)) DEALLOCATE(CH4_OFFSET)
+#endif
 
     ! Trap potential errors
     IF ( RC /= GC_SUCCESS ) THEN

--- a/run/GEOS/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/GEOSCHEMchem_ExtData.yaml
@@ -265,6 +265,11 @@ Collections:
     ref_time: "2001-01-01T00:00"
     freq: "PT3H"
     valid_range: "2001-01-01T00:00/2020-12-31T21:00"
+  Jason_10.18.0_carbon_c90_2023:
+    template: /discover/nobackup/projects/gmao/geos_carb/sbasu1/runs/GCM/Jason_10.18.0_carbon_c90_2023/holding/methane_tags/Jason_10.18.0_carbon_c90_2023.methane_tags.%y4%m2%d2_%h200z.nc
+    ref_time: "2001-01-01T00:00"
+    freq: "PT3H"
+    valid_range: "2001-01-01T00:00/2021-12-31T21:00"
   GEOSCHEMchem_CH4_scaling:
     template: /gpfsm/dnb52/projects/p10/dasilva/fvInput/ExtData/chemistry/CH4/v0.0.0/ch4_offset_to_2021_x144_y91_%y4%m2.nc
     valid_range: "2021-01-01T00:00/2022-12-01T00:00"
@@ -2682,7 +2687,7 @@ Exports:
     sample: gcc_persist 
     variable: s_mn
   GEOS_CH4:
-    collection: Jason_10.18.0_carbon_c90
+    collection: Jason_10.18.0_carbon_c90_2023
     regrid: BILINEAR
     sample: gcc_3hr
     variable: CH4_total_dry

--- a/run/GEOS/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/GEOSCHEMchem_ExtData.yaml
@@ -265,6 +265,11 @@ Collections:
     ref_time: "2001-01-01T00:00"
     freq: "PT3H"
     valid_range: "2001-01-01T00:00/2020-12-31T21:00"
+  GEOSCHEMchem_CH4_scaling:
+    template: /gpfsm/dnb52/projects/p10/dasilva/fvInput/ExtData/chemistry/CH4/v0.0.0/ch4_offset_to_2021_x144_y91_%y4%m2.nc
+    valid_range: "2021-01-01T00:00/2022-12-01T00:00"
+    ref_time: "2021-01-01T00:00"
+    freq: "P1M"
   GCC_CMAM_CO:
     template: /gpfsm/dnb52/projects/p10/dasilva/fvInput/ExtData/chemistry/CMAM/v0.0.0/vmrco_monChem_CMAM_CMAM30-SD_r1i1p1.monthly_clim_0.015hPa.1979_2010.nc
 
@@ -2681,6 +2686,11 @@ Exports:
     regrid: BILINEAR
     sample: gcc_3hr
     variable: CH4_total_dry
+  CH4_OFFSET:
+    collection: GEOSCHEMchem_CH4_scaling
+    regrid: BILINEAR
+    sample: gcc_monthly_clim
+    variable: CH4_offset
   CO_CMAM:
     collection: GCC_CMAM_CO
     regrid: BILINEAR

--- a/run/GEOS/HEMCO_Config.rc
+++ b/run/GEOS/HEMCO_Config.rc
@@ -80,8 +80,9 @@ VerboseOnCores:              root       # Accepted values: root all
     --> GMI_PROD_LOSS          :       false
     --> UCX_PROD_LOSS          :       false
     --> OMOC_RATIO             :       false
-    --> GMD_SFC_CH4            :       true
+    --> GMD_SFC_CH4            :       false
     --> CMIP6_SFC_CH4          :       false
+    --> GEOS_3HR_CH4           :       true
 # OLSON and MODIS read via MAPL not HEMCO in GEOS
     --> OLSON_LANDMAP          :       false
     --> YUAN_MODIS_LAI         :       false
@@ -1358,6 +1359,14 @@ VerboseOnCores:              root       # Accepted values: root all
 (((GMD_SFC_CH4
 * NOAA_GMD_CH4 $ROOT/NOAA_GMD/v2018-01/monthly.gridded.surface.methane.1979-2020.1x1.nc SFC_CH4 1979-2020/1-12/1/0 C xy ppbv * - 1 1 
 )))GMD_SFC_CH4
+
+#==============================================================================
+# --- GEOS 3-hourly CH4 (within PBL) ---
+#==============================================================================
+(((GEOS_3HR_CH4
+* GEOS_CH4   /see/extdata CH4_total_dry 1979-2024/1-12/1-31/0 C xyz v/v * - 1 1
+* CH4_OFFSET /see/extdata CH4_offset    2021-2024/1-12/1/0    C xy  v/v * - 1 1
+)))GEOS_3HR_CH4
 
 (((SfcVMR
 #==============================================================================

--- a/run/GEOS/scripts/create_ch4_offset_file.py
+++ b/run/GEOS/scripts/create_ch4_offset_file.py
@@ -1,0 +1,119 @@
+#!/usr/local/other/python/GEOSpyD/2019.03_py3.7/2019-04-22/bin/python
+'''
+Script to create uniform CH4 offset file that can be read by GEOS to
+add a universal offset to CH4 boundary conditions.
+The offset value can be either passed as input argument or calculated
+online as the difference between the target year and the reference year.
+In case of the latter, the values from the following source are used to
+determine the CH4 increase: 
+- https://gml.noaa.gov/webdata/ccgg/trends/ch4/ch4_mm_gl.txt
+
+EXAMPLES:
+1. Create CH4 growth files relative to 2021 passing explicit values:
+
+Create y/y offset file for January 2022 relative to 2021, using prescribed offset
+python create_ch4_offset_file.py -y 2022 -m 1 -v 17.97e-9 -o 'ch4_offset_to_2021_%Y%m.nc'
+
+Create y/y offset file for January 2023 relative to 2022, using prescribed offset
+python create_ch4_offset_file.py -y 2023 -m 1 -v 14.62e-9 -o 'ch4_offset_to_2022_%Y%m.nc'
+
+Create y/y offset file for January 2023 relative to 2021 by adding y/y offset to 2022/2021 file
+python create_ch4_offset_file.py -y 2023 -m 1 -v 14.62e-9 -i 'ch4_offset_to_2021_2022%m.nc' -o 'ch4_offset_to_2021_%Y%m.nc'
+
+2. Create CH4 growth file relative to 2021 using online computed offset:
+python create_ch4_offset_file.py -y 2023 -m 1 -r 2021 -o 'ch4_offset_to_2021_%Y%m.nc'
+
+HISTORY: 
+20240118 - christoph.a.keller@nasa.gov - initial version
+'''
+import sys
+import argparse
+import logging
+import datetime as dt
+import time
+import numpy as np
+import xarray as xr
+import pandas as pd
+
+# NOAA CH4 data
+URL="https://gml.noaa.gov/webdata/ccgg/trends/ch4/ch4_mm_gl.txt"
+
+def main(args):
+    '''
+    Create a netCDF file with the given offset values. 
+    '''
+    log = logging.getLogger(__name__)
+    # output time
+    otime = dt.datetime(args.year,args.month,1)
+    # offset value: read from online table if not provided
+    offset = np.nan 
+    if args.value is None:
+       log.info('Reading CH4 trends from {}'.format(URL))
+       dat = pd.read_csv(URL,comment="#",header=None,sep='\s+')
+       # get reference values in ppb
+       refconc = dat.loc[(dat[0]==args.refyear)&(dat[1]==args.month),3].values[0]
+       targetconc = dat.loc[(dat[0]==args.year)&(dat[1]==args.month),3].values[0]
+       offset = (targetconc-refconc)*1.0e-9
+       log.info("Calculated offset from URL: {}".format(URL))
+       log.info("reference concentration ({}-{}): {}".format(args.refyear,args.month,refconc))
+       log.info("target concentration ({}-{}): {}".format(args.year,args.month,targetconc))
+       log.info("offset (mol/mol): {}".format(offset))
+    else:
+       offset = args.value
+
+    # define lat/lon coordinates and output array with offsets. 
+    if args.ifile is not None:
+       # Read input file and inherit coordinates from it. Add offset to values in that file
+       ifile = otime.strftime(args.ifile) 
+       log.info('reading {}'.format(ifile))
+       dsi = xr.open_dataset(ifile)
+       lons = dsi.lon.values
+       lats = dsi.lat.values
+       assert args.varname in dsi,"variable {} not found in {}".format(args.varname,args.ifile)
+       assert len(dsi[args.varname].shape)==3,"variable {} must have 3 dimensions (time,lat,lon)".format(args.varname)
+       arr  = dsi[args.varname].values[:,:,:] + offset 
+    else:
+       # Create from scratch 
+       lons = np.arange(-180.,180.,2.5)
+       lats = np.arange(-90.,90.1,2.) 
+       arr = np.zeros((1,len(lats),len(lons)))
+       arr[:] = offset
+
+    # Create output dataset
+    ds = xr.Dataset()
+    ds[args.varname] = (('time','lat','lon'),arr)
+    ds[args.varname].attrs =  {'standard_name':'CH4_offset','long_name':'CH4_offset','units':"mol/mol"}
+    ds.coords['lat'] = (('lat'),lats)
+    ds['lat'].attrs =  {'standard_name':'latitude','long_name':'latitude','units':'degrees_north'}
+    ds.coords['lon'] = (('lon'),lons)
+    ds['lon'].attrs =  {'standard_name':'longitude','long_name':'longitude','units':'degrees_east'}
+    tunit = otime.strftime('days since %Y-%m-%d %H:%M:%S')
+    ds.coords['time'] = (('time'),np.zeros((1,)))
+    ds['time'].attrs =  {'standard_name':'time','long_name':'time','units':tunit,'calendar':'standard'}
+    ofile = otime.strftime(args.ofile)
+    ds.to_netcdf(ofile)
+    log.info('file written to {}'.format(ofile))
+    ds.close()
+    return
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description='Undef certain variables')
+    p.add_argument('-y', '--year',type=int,help='output year',default=2023)
+    p.add_argument('-m', '--month',type=int,help='output month',default=1)
+    p.add_argument('-v', '--value',type=float,help='CH4 offset, in mol/mol dry',default=None)
+    p.add_argument('-r', '--refyear',type=int,help='reference year',default=2021)
+    p.add_argument('-i', '--ifile',type=str,help='input file, will add offset to values in that file',default=None)
+    p.add_argument('-o', '--ofile',type=str,help='output file',default="ch4_offset_to_2021_x144_y91_%Y%m.nc")
+    p.add_argument('-n', '--varname',type=str,help='variable name for offset',default="CH4_offset")
+    return p.parse_args()
+
+
+if __name__ == '__main__':
+    log = logging.getLogger()
+    log.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.INFO)
+    log.addHandler(handler)
+    main(parse_args())
+


### PR DESCRIPTION
### Name and Institution (Required)

Name: Christoph Keller
Institution: NASA GMAO / MSU

### Confirm you have reviewed the following documentation

- [x ] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
This update adds the option to add an offset to the CH4 boundary condition concentrations. This can be useful to incorporate the most recent CH4 trends. For now, this is limited to GEOS runs. However, it would be trivial to make this a general feature (by removing the GEOS compiler brackets). 
The CH4 offset field is obtained through HEMCO. A python script is provided to generate netCDF files that can be read via ExtData.yaml / HEMCO.

### Expected changes
Zero diff

### Reference(s)
[https://gml.noaa.gov/webdata/ccgg/trends/ch4/ch4_mm_gl.txt](https://gml.noaa.gov/webdata/ccgg/trends/ch4/ch4_mm_gl.txt)

### Related Github Issue(s)
N/A
