### PR TITLE
Create new diagnostics for PM25 nitrate and ammonium (GEOS only)

### DIFF
--- a/GeosCore/aerosol_mod.F90
+++ b/GeosCore/aerosol_mod.F90
@@ -1003,6 +1003,22 @@ CONTAINS
                                     * ( T(I,J,L)      / 298.0_fp    ) &
                                     * 1.0e+9_fp
        ENDIF
+
+       ! PM2.5 nitrate 
+       IF ( State_Diag%Archive_PM25nit ) THEN
+          State_Diag%PM25nit(I,J,L) = ( NIT(I,J,L) * SIA_GROWTH  ) &
+                                    * ( 1013.25_fp / PMID(I,J,L) ) &
+                                    * ( T(I,J,L)   / 298.0_fp    ) &
+                                    * 1.0e+9_fp
+       ENDIF
+
+       ! PM2.5 ammonium 
+       IF ( State_Diag%Archive_PM25nh4 ) THEN
+          State_Diag%PM25nh4(I,J,L) = ( NH4(I,J,L) * SIA_GROWTH  ) &
+                                    * ( 1013.25_fp / PMID(I,J,L) ) &
+                                    * ( T(I,J,L)   / 298.0_fp    ) &
+                                    * 1.0e+9_fp
+       ENDIF
 #endif
 
     ENDDO

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -1216,6 +1216,12 @@ MODULE State_Diag_Mod
      REAL(f4),           POINTER :: PM25soa(:,:,:)    ! PM25 SOA
      LOGICAL                     :: Archive_PM25soa
 
+     REAL(f4),           POINTER :: PM25nit(:,:,:)     ! PM25 nitrate
+     LOGICAL                     :: Archive_PM25nit
+
+     REAL(f4),           POINTER :: PM25nh4(:,:,:)     ! PM25 ammonium 
+     LOGICAL                     :: Archive_PM25nh4
+
      !%%%%% Species diagnostics %%%%%
      REAL(f4),           POINTER :: PblCol(:,:,:)
      TYPE(DgnMap),       POINTER :: Map_PblCol
@@ -2372,6 +2378,12 @@ CONTAINS
 
     State_Diag%PM25soa                             => NULL()
     State_Diag%Archive_PM25soa                     = .FALSE.
+
+    State_Diag%PM25nit                             => NULL()
+    State_Diag%Archive_PM25nit                     = .FALSE.
+
+    State_Diag%PM25nh4                             => NULL()
+    State_Diag%Archive_PM25nh4                     = .FALSE.
 
     State_Diag%PblCol                              => NULL()
     State_Diag%Map_PblCol                          => NULL()
@@ -7822,6 +7834,50 @@ CONTAINS
           RETURN
        ENDIF
 
+       !--------------------------------------------------------------------
+       ! PM25 Nitrate 
+       !--------------------------------------------------------------------
+       diagID = 'PM25nit'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%PM25nit,                             &
+            archiveData    = State_Diag%Archive_PM25nit,                     &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
+       !--------------------------------------------------------------------
+       ! PM25 Ammonium 
+       !--------------------------------------------------------------------
+       diagID = 'PM25nh4'
+       CALL Init_and_Register(                                               &
+            Input_Opt      = Input_Opt,                                      &
+            State_Chm      = State_Chm,                                      &
+            State_Diag     = State_Diag,                                     &
+            State_Grid     = State_Grid,                                     &
+            DiagList       = Diag_List,                                      &
+            TaggedDiagList = TaggedDiag_List,                                &
+            Ptr2Data       = State_Diag%PM25nh4,                             &
+            archiveData    = State_Diag%Archive_PM25nh4,                     &
+            diagId         = diagId,                                         &
+            RC             = RC                                             )
+
+       IF ( RC /= GC_SUCCESS ) THEN
+          errMsg = TRIM( errMsg_ir ) // TRIM( diagId )
+          CALL GC_Error( errMsg, RC, thisLoc )
+          RETURN
+       ENDIF
+
        diagID  = 'TotCol'
        CALL Init_and_Register(                                               &
             Input_Opt      = Input_Opt,                                      &
@@ -12061,6 +12117,16 @@ CONTAINS
                    RC       = RC                                            )
     IF ( RC /= GC_SUCCESS ) RETURN
 
+    CALL Finalize( diagId   = 'PM25nit',                                     &
+                   Ptr2Data = State_Diag%PM25nit,                            &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
+    CALL Finalize( diagId   = 'PM25nh4',                                     &
+                   Ptr2Data = State_Diag%PM25nh4,                            &
+                   RC       = RC                                            )
+    IF ( RC /= GC_SUCCESS ) RETURN
+
     CALL Finalize( diagId   = 'TotCol',                                      &
                    Ptr2Data = State_Diag%TotCol,                             &
                    mapData  = State_Diag%Map_TotCol,                         &
@@ -13216,6 +13282,12 @@ CONTAINS
     ELSE IF ( TRIM( Name_AllCaps ) == 'PM25SS' ) THEN
        IF ( isDesc    ) Desc  = &
             'Particulate matter with radii < 2.5 um, sea salt'
+       IF ( isUnits   ) Units = 'ug m-3'
+       IF ( isRank    ) Rank  =  3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'PM25SOA' ) THEN
+       IF ( isDesc    ) Desc  = &
+            'Particulate matter with radii < 2.5 um, SOA'
        IF ( isUnits   ) Units = 'ug m-3'
        IF ( isRank    ) Rank  =  3
 

--- a/Headers/state_diag_mod.F90
+++ b/Headers/state_diag_mod.F90
@@ -13291,9 +13291,15 @@ CONTAINS
        IF ( isUnits   ) Units = 'ug m-3'
        IF ( isRank    ) Rank  =  3
 
-    ELSE IF ( TRIM( Name_AllCaps ) == 'PM25SOA' ) THEN
+    ELSE IF ( TRIM( Name_AllCaps ) == 'PM25NIT' ) THEN
        IF ( isDesc    ) Desc  = &
-            'Particulate matter with radii < 2.5 um, SOA'
+            'Particulate matter with radii < 2.5 um, nitrate'
+       IF ( isUnits   ) Units = 'ug m-3'
+       IF ( isRank    ) Rank  =  3
+
+    ELSE IF ( TRIM( Name_AllCaps ) == 'PM25NH4' ) THEN
+       IF ( isDesc    ) Desc  = &
+            'Particulate matter with radii < 2.5 um, ammonium'
        IF ( isUnits   ) Units = 'ug m-3'
        IF ( isRank    ) Rank  =  3
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Christoph Keller
Institution: NASA GMAO / MSU

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://geos-chem.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
Add separate PM25 diagnostics for nitrate and ammonium (`PM25nit` and `PM25nh4`, respectively). This complements the more generic `PM25ni` diagnostics that contains both components. These diagnostics are currently only available in a GEOS environment.
This update is already included in branch [geoscf/CFv2/rc1](https://github.com/GEOS-ESM/geos-chem/tree/geoscf/CFv2/rc1). 

### Expected changes
Zero-diff. 

### Reference(s)
N/A

### Related Github Issue(s)
N/A
