### PR TITLE
Fix GEOSCHEMchem_ExtData.yaml for GEOS-Chem transport tracers in GEOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [geos/develop] - TBD
+### Fixed
+- Fixed missing FROCEAN and incorrect yaml logical format in GEOS transport tracers GEOSCHEMchem_ExtData.yaml used by ExtData2G
+
 ## [14.5.1] - 2025-01-10
 ### Added
 - Added Australian Hg emissions for 2000-2019 from MacFarlane et. al. [2022], plus corresponding mask file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [geos/develop] - TBD
 ### Fixed
-- Fixed missing FROCEAN and incorrect yaml logical format in GEOS transport tracers GEOSCHEMchem_ExtData.yaml used by ExtData2G
+- Fixed bugs in GEOSCHEMchem_ExtData.yaml used for GEOS-Chem transport tracers simulation in GEOS
 
 ## [14.5.1] - 2025-01-10
 ### Added

--- a/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
@@ -27,6 +27,8 @@ Collections:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.TRO.0.1x0.1.nc
   TT_EDGAR_v43.Seasonal.1x1.nc:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.Seasonal.1x1.nc
+  TT_GEOSCHEMchem_d5294_geosit_jan18.asm_const_0hr_glo_C180x180x6_slv.2018-01-01T0300Z.nc4:
+      template: /gpfsm/dnb06/projects/p171/dao_ops/archive/d5294_geosit_jan18/diag/Y2018/M01/d5294_geosit_jan18.asm_const_0hr_glo_C180x180x6_slv.2018-01-01T0300Z.nc4
   TT_Olson_2001_Land_Map.025x025.generic.nc:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/Olson_Land_Map_201203/Olson_2001_Land_Map.025x025.generic.nc
   TT_Rn222_Emis_Zhang_Liu_et_al_05x05_mass.nc:
@@ -41,16 +43,16 @@ Samplings:
     update_frequency: PT24H
     update_reference_time: '0'
   TT_sample_2:
-    time_interpolation: 'False'
+    time_interpolation: False
     update_frequency: P1Y
     update_reference_time: '0'
   TT_sample_3:
-    time_interpolation: 'False'
+    time_interpolation: False
     update_frequency: P1M
     update_reference_time: '0'
   TT_sample_4:
     extrapolation: clim
-    time_interpolation: 'False'
+    time_interpolation: False
     update_frequency: P1M
     update_reference_time: '0'
 
@@ -184,6 +186,11 @@ Exports:
     regrid: CONSERVE
     sample: TT_sample_2
     variable: COscalar
+  OCEAN_MASK:
+    collection: TT_GEOSCHEMchem_d5294_geosit_jan18.asm_const_0hr_glo_C180x180x6_slv.2018-01-01T0300Z.nc4
+    regrid: CONSERVE
+    sample: TT_sample_0
+    variable: FROCEAN
   OLSON00:
     collection: TT_Olson_2001_Land_Map.025x025.generic.nc
     regrid: FRACTION;0

--- a/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
@@ -1,29 +1,40 @@
 Collections:
   TT_AnnualScalar.geos.1x1.nc:
+    valid_range: "1985-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc
   TT_CO-em-anthro_CMIP_CEDS_%y4.nc:
+    valid_range: "1750-01-01/2019-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/CEDS/v2021-06/%y4/CO-em-anthro_CMIP_CEDS_%y4.nc
   TT_Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/Yuan_XLAI/v2019-03/Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc
   TT_EDGAR_v42_SF6_IPCC_2.generic.01x01.nc:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/SF6/v2019-01/EDGAR_v42_SF6_IPCC_2.generic.01x01.nc
   TT_EDGAR_v43.CO.ENG.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.ENG.0.1x0.1.nc
   TT_EDGAR_v43.CO.FFF.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.FFF.0.1x0.1.nc
   TT_EDGAR_v43.CO.IND.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.IND.0.1x0.1.nc
   TT_EDGAR_v43.CO.POW.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc
   TT_EDGAR_v43.CO.PPA.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.PPA.0.1x0.1.nc
   TT_EDGAR_v43.CO.RCO.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.RCO.0.1x0.1.nc
   TT_EDGAR_v43.CO.SWD.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.SWD.0.1x0.1.nc
   TT_EDGAR_v43.CO.TNG.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.TNG.0.1x0.1.nc
   TT_EDGAR_v43.CO.TRO.0.1x0.1.nc:
+    valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.TRO.0.1x0.1.nc
   TT_EDGAR_v43.Seasonal.1x1.nc:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.Seasonal.1x1.nc

--- a/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
@@ -1,7 +1,4 @@
 Collections:
-  GEOSCHEMchem_AnnualScalar:
-    valid_range: "1985-01-01/2010-01-01"
-    template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc
   GEOSCHEMchem_CO-em-anthro_CMIP_CEDS:
     valid_range: "1750-01-01/2019-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/CEDS/v2021-06/%y4/CO-em-anthro_CMIP_CEDS_%y4.nc
@@ -176,16 +173,6 @@ Exports:
     regrid: CONSERVE
     sample: monthly
     variable: IND
-  LIQFUEL_2008_2010:
-    collection: GEOSCHEMchem_AnnualScalar
-    regrid: CONSERVE
-    sample: annual
-    variable: COscalar
-  LIQFUEL_THISYR:
-    collection: GEOSCHEMchem_AnnualScalar
-    regrid: CONSERVE
-    sample: annual
-    variable: COscalar
   OCEAN_MASK:
     collection: GEOSCHEMchem_GEOS_IT_constants
     regrid: CONSERVE

--- a/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
@@ -1,621 +1,608 @@
 Collections:
-  TT_AnnualScalar.geos.1x1.nc:
+  GEOSCHEMchem_AnnualScalar:
     valid_range: "1985-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/AnnualScalar/v2014-07/AnnualScalar.geos.1x1.nc
-  TT_CO-em-anthro_CMIP_CEDS_%y4.nc:
+  GEOSCHEMchem_CO-em-anthro_CMIP_CEDS:
     valid_range: "1750-01-01/2019-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/CEDS/v2021-06/%y4/CO-em-anthro_CMIP_CEDS_%y4.nc
-  TT_Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc:
+  GEOSCHEMchem_Condensed_Yuan_proc_MODIS_XLAI:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/Yuan_XLAI/v2019-03/Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc
-  TT_EDGAR_v42_SF6_IPCC_2.generic.01x01.nc:
+  GEOSCHEMchem_EDGAR_v42_SF6_IPCC_2:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/SF6/v2019-01/EDGAR_v42_SF6_IPCC_2.generic.01x01.nc
-  TT_EDGAR_v43.CO.ENG.0.1x0.1.nc:
+  GEOSCHEMchem_EDGAR_v43.CO.ENG:
     valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.ENG.0.1x0.1.nc
-  TT_EDGAR_v43.CO.FFF.0.1x0.1.nc:
+  GEOSCHEMchem_EDGAR_v43.CO.FFF:
     valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.FFF.0.1x0.1.nc
-  TT_EDGAR_v43.CO.IND.0.1x0.1.nc:
+  GEOSCHEMchem_EDGAR_v43.CO.IND:
     valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.IND.0.1x0.1.nc
-  TT_EDGAR_v43.CO.POW.0.1x0.1.nc:
+  GEOSCHEMchem_EDGAR_v43.CO.POW:
     valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.POW.0.1x0.1.nc
-  TT_EDGAR_v43.CO.PPA.0.1x0.1.nc:
+  GEOSCHEMchem_EDGAR_v43.CO.PPA:
     valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.PPA.0.1x0.1.nc
-  TT_EDGAR_v43.CO.RCO.0.1x0.1.nc:
+  GEOSCHEMchem_EDGAR_v43.CO.RCO:
     valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.RCO.0.1x0.1.nc
-  TT_EDGAR_v43.CO.SWD.0.1x0.1.nc:
+  GEOSCHEMchem_EDGAR_v43.CO.SWD:
     valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.SWD.0.1x0.1.nc
-  TT_EDGAR_v43.CO.TNG.0.1x0.1.nc:
+  GEOSCHEMchem_EDGAR_v43.CO.TNG:
     valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.TNG.0.1x0.1.nc
-  TT_EDGAR_v43.CO.TRO.0.1x0.1.nc:
+  GEOSCHEMchem_EDGAR_v43.CO.TRO:
     valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.TRO.0.1x0.1.nc
-  TT_EDGAR_v43.Seasonal.1x1.nc:
+  GEOSCHEMchem_EDGAR_v43.Seasonal:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.Seasonal.1x1.nc
   TT_GEOSCHEMchem_d5294_geosit_jan18.asm_const_0hr_glo_C180x180x6_slv.2018-01-01T0300Z.nc4:
       template: /gpfsm/dnb06/projects/p171/dao_ops/archive/d5294_geosit_jan18/diag/Y2018/M01/d5294_geosit_jan18.asm_const_0hr_glo_C180x180x6_slv.2018-01-01T0300Z.nc4
-  TT_Olson_2001_Land_Map.025x025.generic.nc:
+  GEOSCHEMchem_Olson_2001_Land_Map:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/Olson_Land_Map_201203/Olson_2001_Land_Map.025x025.generic.nc
-  TT_Rn222_Emis_Zhang_Liu_et_al_05x05_mass.nc:
+  GEOSCHEMchem_Rn222_Emis_Zhang_Liu_et_al:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/ZHANG_Rn222/v2021-11/Rn222_Emis_Zhang_Liu_et_al_05x05_mass.nc
-  TT_timezones_esmf.2x25.nc:
+  GEOSCHEMchem_timezones:
     template: /discover/nobackup/cakelle2/data/timezones_esmf.2x25.nc
 
 Samplings:
-  TT_sample_0:
-    extrapolation: persist_closest
-  TT_sample_1:
-    update_frequency: PT24H
-    update_reference_time: '0'
-  TT_sample_2:
-    time_interpolation: False
-    update_frequency: P1Y
-    update_reference_time: '0'
-  TT_sample_3:
-    time_interpolation: False
-    update_frequency: P1M
-    update_reference_time: '0'
-  TT_sample_4:
-    extrapolation: clim
-    time_interpolation: False
-    update_frequency: P1M
-    update_reference_time: '0'
+  constant:              { extrapolation: persist_closest }
+  daily_interp:          { extrapolation: clim, update_reference_time: '0',  update_frequency: PT24H, time_interpolation: False }    
+  8day_interp_clim:      { extrapolation: clim, update_reference_time: '0',  update_frequency: P8D,   time_interpolation: True, update_offset: P1D }
+  annual:                { extrapolation: clim, update_reference_time: '0',  update_frequency: P1Y,   time_interpolation: False }
+  monthly:               { extrapolation: clim, update_reference_time: '0',  update_frequency: P1M,   time_interpolation: False }
 
 Exports:
   AGR:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: AGR
   AWB:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: AWB
   CEDS_CO_25_AGR:
-    collection: TT_CO-em-anthro_CMIP_CEDS_%y4.nc
+    collection: GEOSCHEMchem_CO-em-anthro_CMIP_CEDS
     regrid: CONSERVE
-    sample: TT_sample_3
+    sample: monthly
     variable: CO_agr
   CEDS_CO_25_ENE:
-    collection: TT_CO-em-anthro_CMIP_CEDS_%y4.nc
+    collection: GEOSCHEMchem_CO-em-anthro_CMIP_CEDS
     regrid: CONSERVE
-    sample: TT_sample_3
+    sample: monthly
     variable: CO_ene
   CEDS_CO_25_IND:
-    collection: TT_CO-em-anthro_CMIP_CEDS_%y4.nc
+    collection: GEOSCHEMchem_CO-em-anthro_CMIP_CEDS
     regrid: CONSERVE
-    sample: TT_sample_3
+    sample: monthly
     variable: CO_ind
   CEDS_CO_25_RCO:
-    collection: TT_CO-em-anthro_CMIP_CEDS_%y4.nc
+    collection: GEOSCHEMchem_CO-em-anthro_CMIP_CEDS
     regrid: CONSERVE
-    sample: TT_sample_3
+    sample: monthly
     variable: CO_rco
   CEDS_CO_25_SHP:
-    collection: TT_CO-em-anthro_CMIP_CEDS_%y4.nc
+    collection: GEOSCHEMchem_CO-em-anthro_CMIP_CEDS
     regrid: CONSERVE
-    sample: TT_sample_3
+    sample: monthly
     variable: CO_shp
   CEDS_CO_25_SLV:
-    collection: TT_CO-em-anthro_CMIP_CEDS_%y4.nc
+    collection: GEOSCHEMchem_CO-em-anthro_CMIP_CEDS
     regrid: CONSERVE
-    sample: TT_sample_3
+    sample: monthly
     variable: CO_slv
   CEDS_CO_25_TRA:
-    collection: TT_CO-em-anthro_CMIP_CEDS_%y4.nc
+    collection: GEOSCHEMchem_CO-em-anthro_CMIP_CEDS
     regrid: CONSERVE
-    sample: TT_sample_3
+    sample: monthly
     variable: CO_tra
   CEDS_CO_25_WST:
-    collection: TT_CO-em-anthro_CMIP_CEDS_%y4.nc
+    collection: GEOSCHEMchem_CO-em-anthro_CMIP_CEDS
     regrid: CONSERVE
-    sample: TT_sample_3
+    sample: monthly
     variable: CO_wst
   CONV_DEPTH:
     collection: /dev/null
   EDGAR_CO_25_ENG:
-    collection: TT_EDGAR_v43.CO.ENG.0.1x0.1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.CO.ENG
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: emi_co
   EDGAR_CO_25_FFF:
-    collection: TT_EDGAR_v43.CO.FFF.0.1x0.1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.CO.FFF
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: emi_co
   EDGAR_CO_25_IND:
-    collection: TT_EDGAR_v43.CO.IND.0.1x0.1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.CO.IND
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: emi_co
   EDGAR_CO_25_POW:
-    collection: TT_EDGAR_v43.CO.POW.0.1x0.1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.CO.POW
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: emi_co
   EDGAR_CO_25_PPA:
-    collection: TT_EDGAR_v43.CO.PPA.0.1x0.1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.CO.PPA
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: emi_co
   EDGAR_CO_25_RCO:
-    collection: TT_EDGAR_v43.CO.RCO.0.1x0.1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.CO.RCO
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: emi_co
   EDGAR_CO_25_SWD:
-    collection: TT_EDGAR_v43.CO.SWD.0.1x0.1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.CO.SWD
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: emi_co
   EDGAR_CO_25_TNG:
-    collection: TT_EDGAR_v43.CO.TNG.0.1x0.1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.CO.TNG
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: emi_co
   EDGAR_CO_25_TRO:
-    collection: TT_EDGAR_v43.CO.TRO.0.1x0.1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.CO.TRO
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: emi_co
   EDGAR_SF6:
-    collection: TT_EDGAR_v42_SF6_IPCC_2.generic.01x01.nc
+    collection: GEOSCHEMchem_EDGAR_v42_SF6_IPCC_2
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: emi_sf6
   ENG:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: ENG
   FFF:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: FFF
   FLASH_DENS:
     collection: /dev/null
   IND:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: IND
   LIQFUEL_2008_2010:
-    collection: TT_AnnualScalar.geos.1x1.nc
+    collection: GEOSCHEMchem_AnnualScalar
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: COscalar
   LIQFUEL_THISYR:
-    collection: TT_AnnualScalar.geos.1x1.nc
+    collection: GEOSCHEMchem_AnnualScalar
     regrid: CONSERVE
-    sample: TT_sample_2
+    sample: annual
     variable: COscalar
   OCEAN_MASK:
-    collection: TT_GEOSCHEMchem_d5294_geosit_jan18.asm_const_0hr_glo_C180x180x6_slv.2018-01-01T0300Z.nc4
+    collection: GEOSCHEMchem_GEOS_IT_constants
     regrid: CONSERVE
-    sample: TT_sample_0
+    sample: constant
     variable: FROCEAN
   OLSON00:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;0
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON01:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;1
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON02:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;2
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON03:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;3
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON04:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;4
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON05:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;5
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON06:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;6
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON07:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;7
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON08:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;8
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON09:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;9
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON10:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;10
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON11:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;11
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON12:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;12
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON13:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;13
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON14:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;14
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON15:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;15
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON16:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;16
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON17:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;17
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON18:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;18
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON19:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;19
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON20:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;20
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON21:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;21
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON22:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;22
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON23:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;23
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON24:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;24
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON25:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;25
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON26:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;26
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON27:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;27
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON28:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;28
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON29:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;29
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON30:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;30
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON31:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;31
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON32:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;32
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON33:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;33
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON34:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;34
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON35:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;35
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON36:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;36
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON37:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;37
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON38:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;38
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON39:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;39
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON40:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;40
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON41:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;41
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON42:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;42
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON43:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;43
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON44:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;44
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON45:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;45
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON46:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;46
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON47:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;47
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON48:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;48
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON49:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;49
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON50:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;50
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON51:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;51
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON52:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;52
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON53:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;53
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON54:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;54
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON55:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;55
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON56:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;56
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON57:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;57
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON58:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;58
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON59:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;59
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON60:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;60
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON61:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;61
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON62:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;62
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON63:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;63
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON64:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;64
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON65:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;65
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON66:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;66
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON67:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;67
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON68:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;68
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON69:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;69
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON70:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;70
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON71:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;71
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   OLSON72:
-    collection: TT_Olson_2001_Land_Map.025x025.generic.nc
+    collection: GEOSCHEMchem_Olson_2001_Land_Map
     regrid: FRACTION;72
-    sample: TT_sample_0
+    sample: constant
     variable: OLSON
   POW:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: POW
   PPA:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: PPA
   RCO:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: RCO
   SOL:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: SOL
   SWD:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: SWD
   TIMEZONES:
-    collection: TT_timezones_esmf.2x25.nc
+    collection: GEOSCHEMchem_timezones
     regrid: VOTE
-    sample: TT_sample_0
+    sample: constant
     variable: UTC_OFFSET
   TNG:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: TNG
   TRO:
-    collection: TT_EDGAR_v43.Seasonal.1x1.nc
+    collection: GEOSCHEMchem_EDGAR_v43.Seasonal
     regrid: CONSERVE
-    sample: TT_sample_4
+    sample: monthly
     variable: TRO
   XLAIMULTI:
-    collection: TT_Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc
+    collection: GEOSCHEMchem_Condensed_Yuan_proc_MODIS_XLAI
     regrid: CONSERVE
-    sample: TT_sample_1
+    sample: daily_interp
     variable: XLAIMULTI
   ZHANG_Rn222_EMIS:
-    collection: TT_Rn222_Emis_Zhang_Liu_et_al_05x05_mass.nc
+    collection: GEOSCHEMchem_Rn222_Emis_Zhang_Liu_et_al
     regrid: CONSERVE
-    sample: TT_sample_3
+    sample: monthly
     variable: rnemis
 
 

--- a/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
@@ -6,8 +6,10 @@ Collections:
     valid_range: "1750-01-01/2019-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/CEDS/v2021-06/%y4/CO-em-anthro_CMIP_CEDS_%y4.nc
   GEOSCHEMchem_Condensed_Yuan_proc_MODIS_XLAI:
+    valid_range: "2000-01-01/2020-12-31T00:00"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/Yuan_XLAI/v2019-03/Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc
   GEOSCHEMchem_EDGAR_v42_SF6_IPCC_2:
+    valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/SF6/v2019-01/EDGAR_v42_SF6_IPCC_2.generic.01x01.nc
   GEOSCHEMchem_EDGAR_v43.CO.ENG:
     valid_range: "1970-01-01/2010-01-01"

--- a/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
@@ -1,12 +1,12 @@
 Collections:
   GEOSCHEMchem_CO-em-anthro_CMIP_CEDS:
-    valid_range: "1750-01-01/2019-01-01"
+    valid_range: "1750-01-01/2019-12-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/CEDS/v2021-06/%y4/CO-em-anthro_CMIP_CEDS_%y4.nc
   GEOSCHEMchem_Condensed_Yuan_proc_MODIS_XLAI:
-    valid_range: "2000-01-01/2020-12-31T00:00"
+    valid_range: "2000-01-01/2040-12-31T00:00"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/Yuan_XLAI/v2021-06/Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc
   GEOSCHEMchem_EDGAR_v42_SF6_IPCC_2:
-    valid_range: "1970-01-01/2010-01-01"
+    valid_range: "1970-01-01/2008-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/SF6/v2019-01/EDGAR_v42_SF6_IPCC_2.generic.01x01.nc
   GEOSCHEMchem_EDGAR_v43.CO.ENG:
     valid_range: "1970-01-01/2010-01-01"

--- a/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
@@ -38,8 +38,8 @@ Collections:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.CO.TRO.0.1x0.1.nc
   GEOSCHEMchem_EDGAR_v43.Seasonal:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/EDGARv43/v2016-11/EDGAR_v43.Seasonal.1x1.nc
-  TT_GEOSCHEMchem_d5294_geosit_jan18.asm_const_0hr_glo_C180x180x6_slv.2018-01-01T0300Z.nc4:
-      template: /gpfsm/dnb06/projects/p171/dao_ops/archive/d5294_geosit_jan18/diag/Y2018/M01/d5294_geosit_jan18.asm_const_0hr_glo_C180x180x6_slv.2018-01-01T0300Z.nc4
+  GEOSCHEMchem_GEOS_IT_constants:
+    template: /discover/nobackup/projects/gmao/geos-it/dao_ops/archive/d5294_geosit_jan18/diag/Y2018/M01/d5294_geosit_jan18.asm_const_0hr_glo_C180x180x6_slv.2018-01-01T0300Z.nc4
   GEOSCHEMchem_Olson_2001_Land_Map:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/GEOSCHEMchem/v0.0.0/CHEM_INPUTS/Olson_Land_Map_201203/Olson_2001_Land_Map.025x025.generic.nc
   GEOSCHEMchem_Rn222_Emis_Zhang_Liu_et_al:

--- a/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
+++ b/run/GEOS/TransportTracers/GEOSCHEMchem_ExtData.yaml
@@ -7,7 +7,7 @@ Collections:
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/CEDS/v2021-06/%y4/CO-em-anthro_CMIP_CEDS_%y4.nc
   GEOSCHEMchem_Condensed_Yuan_proc_MODIS_XLAI:
     valid_range: "2000-01-01/2020-12-31T00:00"
-    template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/Yuan_XLAI/v2019-03/Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc
+    template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/Yuan_XLAI/v2021-06/Condensed_Yuan_proc_MODIS_XLAI.025x025.%y4.nc
   GEOSCHEMchem_EDGAR_v42_SF6_IPCC_2:
     valid_range: "1970-01-01/2010-01-01"
     template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/ExtData/chemistry/SF6/v2019-01/EDGAR_v42_SF6_IPCC_2.generic.01x01.nc


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR contains fixes to allow running ExtData2G with GEOS-Chem transport tracer simulation within GEOS. Changes include:
- Update formatting of sample logicals (no quotes)
- Remove annual scale factor imports since used only with HTAP which is not used in GEOS
- Add valid date ranges for all imports that span multiple years
- Rename ExtData yaml file sampling and collection names to be both more generic and descriptive
- Update the Yuan condensed XLAI inventory to use the same source as the GEOS-Chem standard model
- Change the GEOS-IT data path prefix to the shared directory on discover
- Update the data interpolation used for XLAI to match what is used for the GEOS-Chem full chemistry simulation in GEOS

Note also that I added a section to the GEOS-Chem changelog for geos/develop changes. This can be used for all other updates that go into geos/develop. I can use that information when bringing GEOS updates into the standard model.

### Expected changes

Successfully read GEOSCHEMchem_ExtData.yaml when using GEOS-Chem transport tracer simulation in GEOSgcm.

### Reference(s)

None

### Related Github Issue

None
