### PR TITLE
Make transport tracers GEOSCHEMchem_GridComp.rc more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This file documents all notable changes to the GEOS-Chem repository starting in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [geos/develop] - TBD
+### Changed
+- Updated GEOSCHEMchem_GridComp.rc used for GEOS-Chem transport tracers simulation in GEOS to explicitly turn off certain options
+
 ### Fixed
 - Fixed bugs in GEOSCHEMchem_ExtData.yaml used for GEOS-Chem transport tracers simulation in GEOS
 

--- a/run/GEOS/TransportTracers/GEOSCHEMchem_GridComp.rc
+++ b/run/GEOS/TransportTracers/GEOSCHEMchem_GridComp.rc
@@ -14,6 +14,7 @@
 #  19 Mar 2013 - R. Yantosca - MAX_TRCS should be 53, not 54
 #  01 Aug 2014 - M. Long-sca - MAX_TRCS & MAX_DIAG set to 130 & 80, resp.
 #  07 Jun 2018 - C.Keller/K.E.Knowland - Change LLSTRAT from 59 to 40, add Calc_VUD_online
+#  14 Apr 2024 - P. O. Sturm - Added optional parallelization timing flag
 #------------------------------------------------------------------------------
 
 #
@@ -39,12 +40,11 @@ CHEMISTRY_TIMESTEP:   1800
 #
 # %%% Placeholder fields for Input_Opt object %%%
 #
-MAX_DIAG:             10
-MAX_TRCS:             25
+MAX_DIAG:             80
+MAX_TRCS:             130
 MAX_MEMB:             15
 MAX_FAMS:             20
-MAX_DEP:              25
-
+MAX_DEP:              55
 
 # Maximum level used for chemistry. If not extending to the top of the atmosphere,
 # production and loss rates from an offline GMI simulation will be applied to the 
@@ -53,17 +53,10 @@ MAX_DEP:              25
 # This is the default.
 #LLSTRAT:              72
 
-
 #
 # %%% Run phases (1 or 2. 2 recommended) %%% 
 #
 RUN_PHASES:        2
-
-#
-# %%% Stop if KPP integration fails (default: 1) %%% 
-#
-KPP_STOP_IF_FAIL:  0
-
 
 #
 # %%% HEMCO configuration file %%%
@@ -77,20 +70,134 @@ STDOUT_LOGFILE:       PET%%%%%.GEOSCHEMchem.log
 STDOUT_LOGLUN:        6
 
 #
+# %%% Initialize all concentrations to zero? ###
+#
+INIT_ZERO:            0
+
+#
 # %%% Use archived convection fields? %%% 
 #
 ARCHIVED_CONV:        0
 
+#
 # %%% Use MOIST module for convective transport (including washout)
+#
 # Make species friendly to moist? If turned on, convection must be turned off in in geoschem_config.yml
 Species_friendly_to_moist: 1
-
+#
+# Turn off washout for SO2?
+TurnOff_SO2_washout: 1
+#
 # Calculate CLDLIQ and CLDICE online based on current conditions (use default GEOS-Chem parameterization otherwise)?
 Online_CLDLIQ: 1
+#
 # Use online vertical updraft velocity or use default GEOS-Chem parameterization? 
 Online_VUD: 1
+
+# make aerosols friendly to GAAS?
+Species_friendly_to_GAAS: 0
+
+#
+# %%% Tuning parameter to reduce washout efficiency
+# %%% of convective large-scale precip.
+# %%% Use at own risk: the effects of setting this
+# %%% parameter to a value between 0.0 and 1.0 are
+# %%% untested!
+#
+### cakelle2, 20180828: bug fix, changed from -999.0 to 1.0
+Convective_precip_correction: 1.0
+
+#
+# %%% Cap polar tropopause at 200hPa (default=yes)? %%%
+#
+Cap_polar_tropopause: 0
+
+#
+# %%% Ozonopause value in ppb. If set to <= 0.0, the
+# %%% GEOS-5 tropopause will be used (default)
+#
+Use_ozonopause: -999.0
 
 #
 # %%% Prescribe stratospheric H2O
 #
 Prescribe_strat_H2O: 1
+
+# Apply H2O tendency to Q?
+# 1  = always do it
+# 0  = only do it if GEOSCHEMCHEM is RATS provider
+# -1 = never do it
+ApplyQtend: -1
+
+#
+# %%% Settings for excluding species from being transported
+#
+Reduce_transport_species: 0
+
+#
+# %%% Include short-lived species in internal restart file?
+#
+Shortlived_species_in_restart: 0
+
+#
+# %%% Read initial conditions from external file
+# %%% instead of internal state
+#
+INIT_SPC_FROM_FILE: 0
+INIT_SPC_FILE: /discover/nobackup/cakelle2/GCC_Restarts/v13.1.0-beta.1/GEOSChem.Restart.20190801_0000z.edit.incHEMCO.nc4
+ONLY_SHORTLIVED_SPECIES: 0
+UNIFORM_IF_MISSING: 1.0e-12
+DATA_IS_IN_PPBV: 1
+ONLY_ON_FIRST_STEP: 1
+DATA_ON_GEOS_LEVELS: 1
+DO_NOT_OVERWRITE_ABOVE_LEVEL: 59
+
+USE_GMI_MESO: 0
+GMI_TEMPLATE: /discover/nobackup/cakelle2/data/GMI/gmi.clim.%spc.geos5.2x25.esmf.nc
+
+#
+# %%% Use GMI P/L for O3 (default=no)? %%%
+#
+Use_GMI_O3_PL:        0
+
+# Turn off heterogenous reactions in stratosphere?
+# If true, the following heterogeneous reactions are disabled (in the stratosphere):
+# ClNO3(g) + HBr(l,s) --> BrCl + HNO3
+# BrNO3(g) + HCl(l,s) --> BrCl + HNO3
+# HOCl(g) + HBr(l,s) --> BrCl + H2O
+TurnOffHetRates: 1
+
+#
+# Enable Bry and Cly family transport
+#
+Bry_Cly_Family_Transport: 0
+
+# Skip GCC during replay predictor step
+# Set to 0 is running composition DA
+SkipReplayGCC: 1
+
+#
+# CO production from CO2 photolysis
+#
+CO_production_from_CO2_photolysis: 0
+
+#
+# CO2 coupling with GOCART
+# Setting this to 1 changes the CO2 in GOCART history. Needs to be checked.
+Import_CO2_from_GOCART: 0
+
+#
+# Set CO mesosphere upper boundary to external field
+#
+Set_CO_Mesosphere: 0
+
+#
+# To set CH4 boundary condition from GEOS
+# This is not yet implemented. Set to zero for now. If you want GEOS CH4, need to activate GEOS_CH4 in HEMCO_Config.rc
+CH4_from_GEOS: 0
+
+
+# Parallelization barrier for chemistry in GEOS
+# Optional VMBarrier at the end of Run2
+# If 1, the VMBarrier is on
+GC_VMBarrier_Run2: 0


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR updates config file `GEOSCHEMchem_GridComp.rc` used for the GEOS-Chem transport tracers in GEOS. The file now matches the one used for full chemistry except with options not used turned off and KPP options excluded. Previously several settings were excluded from the file and this caused problems at run-time because the default when excluded is on not off.

### Expected changes

None

### Reference(s)

None

### Related Github Issue

None
