### PR TITLE
Fix GEOS-Chem diagnostics in transport tracer runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [geos/develop] - TBD
 ### Fixed
 - Fixed bugs in GEOSCHEMchem_ExtData.yaml used for GEOS-Chem transport tracers simulation in GEOS
+- Fixed zero values in GEOS-Chem diagnostics when not using analysis phase
 
 ### Changed
 - Updated GEOS-only transport tracer HISTORY.rc to configure time-averaging period of diagnostics to start at midnight.

--- a/Interfaces/GCHP/Chem_GridCompMod.F90
+++ b/Interfaces/GCHP/Chem_GridCompMod.F90
@@ -3035,11 +3035,11 @@ CONTAINS
           ! Call GEOS analysis routine
           CALL GEOS_AnaRun( Input_Opt, State_Met, State_Chm, State_Grid, &
                             State_Diag, __RC__ )
-
-          ! GEOS Diagnostics. This includes the 'default' GEOS-Chem diagnostics.
-          CALL GEOS_Diagnostics( GC, IMPORT, EXPORT, Clock, Phase, Input_Opt, &
-                                 State_Met, State_Chm, State_Diag, State_Grid, __RC__ )
        ENDIF
+
+       ! GEOS Diagnostics. This includes the 'default' GEOS-Chem diagnostics.
+       CALL GEOS_Diagnostics( GC, IMPORT, EXPORT, Clock, Phase, Input_Opt, &
+            State_Met, State_Chm, State_Diag, State_Grid, __RC__ )
 
        ! Fill RATS and OX diagnostics
        IF ( PHASE == RATSPHASE ) THEN


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR moves the call to [geos_diagnostics](https://github.com/GEOS-ESM/geos-chem/blob/273172aa694e9f7627c06c960684fbb3cc14cbbd/Interfaces/GEOS/geos_interface.F90#L1209) out of an if block for `ANAPHASE`. Having the call within that block resulted in all zeros in GEOS-Chem diagnostics when running with transport tracers and not full chemistry. The default for those runs is to have analysis turned off.

### Expected changes

This update restores non-zero values to GEOS-Chem diagnostics in GEOS runs with analysis turned off, including the transport tracer simulation.

### Reference(s)

None

### Related Github Issue

None
